### PR TITLE
feat: add QOL function mkcd

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -31,6 +31,10 @@ alias lg='lazygit'
 eval "$(zoxide init zsh)"
 eval "$(fzf --zsh)"
 
+function mkcd() {
+  mkdir -p $@ && cd ${@:$#}
+}
+
 # Yazi
 function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd


### PR DESCRIPTION
With `mkcd`, we can now create and cd directly into a directory, saving our poor fingers from having to type more. This comes by default with oh-my-zsh, but I like it so much I want to have it in my .zshrc in case I opt to use something else in the future. 
